### PR TITLE
Fix Git ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
- __pycache__/
- .github/
+__pycache__/
+.github/


### PR DESCRIPTION
Remove the leading space from each entry in `.gitignore` as they prevent `__pycache__` from being ignored correctly.