### PR TITLE
Support Symlinks

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 import traceback
 import asyncio
 
-from watchdog.observers import Observer
+from watchdog.observers.polling import PollingObserver as Observer
 from watchdog.events import FileSystemEventHandler
 from aiohttp import web
 import folder_paths


### PR DESCRIPTION
It's safer to symlink one's git repo into ComfyUI's `custom_nodes` folder rather than working in there directly, where it may be modified/moved/removed by ComfyUIManager and such. However, HotReload currently ignored symlinked folders. This PR fixes that.